### PR TITLE
Fix Pest Tests CI workflow by removing unnecessary SQLite service con…

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -10,15 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    services:
-      sqlite:
-        image: nouchka/sqlite3:latest
-        options: >-
-          --health-cmd "sqlite3 --version"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
…tainer

## Issue
CI was failing with "Service container sqlite failed" error because the nouchka/sqlite3:latest Docker container failed to initialize.

## Root Cause
Laravel can handle SQLite databases directly without needing a Docker service container. The service container was unnecessary and causing the CI failure.

## Solution
- Remove the `services` section entirely
- Keep SQLite database creation using native filesystem commands
- Maintain all PHP extensions including pdo_sqlite
- Environment variables remain the same for proper Laravel test configuration

## Result
✅ Simplified, faster CI workflow
✅ No dependency on external Docker containers
✅ Laravel handles SQLite natively as intended
✅ All 102 tests should now run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)